### PR TITLE
Build scheduler with Dockerfile, use Mirror docker network.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
+# Build
+FROM ubuntu:latest as builder
+RUN apt update && apt upgrade -y
+RUN apt install -y g++ cmake libzmq3-dev ninja-build git
+WORKDIR /sync_scheduler
+COPY ./src /sync_scheduler/src
+COPY ./mirror-logging /sync_scheduler/mirror-logging
+COPY CMakeLists.txt /sync_scheduler/CMakeLists.txt
+RUN cmake -S/sync_scheduler -B/sync_scheduler/build -G Ninja
+RUN cmake --build /sync_scheduler/build --target clean
+RUN cmake --build /sync_scheduler/build --target all
+
+# Run
 FROM ubuntu:latest
-WORKDIR /mirror
-RUN apt update
-RUN apt upgrade -y
+RUN apt update && apt upgrade -y
 RUN apt install -y libzmq3-dev rsync
-COPY build/syncScheduler /mirror/syncScheduler
+WORKDIR /mirror/sync_scheduler
+COPY --from=builder /sync_scheduler/build/syncScheduler /mirror/sync_scheduler/syncScheduler
 ENTRYPOINT ["./syncScheduler"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,13 @@
-version: '3.8'
 services:
   app:
     build: .
     container_name: sync_scheduler
     restart: unless-stopped
-#    links:
-#      - "mirrorlog:log_server"
     volumes:
       - "/storage:/storage"
       - "./configs:/mirror/configs"
+    networks:
+      - mirror
     deploy:
       resources:
         limits:
@@ -16,3 +15,7 @@ services:
           memory: 8192M
     stdin_open: true
     tty: true
+
+networks:
+  mirror:
+    external: true


### PR DESCRIPTION
Changed Dockerfile and docker-compose.yml to have Docker build the sync scheduler in a separate container and transfer the binaries to the host container, and to put the host container on the mirror network.